### PR TITLE
Feature: Error Message for Unimplemented Endpoints

### DIFF
--- a/src/app/api/data/company/route.ts
+++ b/src/app/api/data/company/route.ts
@@ -14,12 +14,18 @@ export async function GET(req: NextRequest) {
   });
 
   if (!resp.ok) {
-    const details = await resp.text();
+    const details = await resp.json().catch(() => ({}));
+    if (resp.status === 404 || resp.status === 501) {
+      return NextResponse.json(
+        { error: "not_implemented" },
+        { status: resp.status }
+      );
+    }
     return NextResponse.json(
       { error: "Failed to fetch company", details },
       { status: resp.status }
     );
-  }
+  }  
 
   const data = await resp.json();
   return NextResponse.json(data);

--- a/src/app/api/data/directory/route.ts
+++ b/src/app/api/data/directory/route.ts
@@ -14,12 +14,19 @@ export async function GET(req: NextRequest) {
   });
 
   if (!resp.ok) {
-    const details = await resp.text();
+    const details = await resp.json().catch(() => ({}));
+    if (resp.status === 404 || resp.status === 501) {
+      return NextResponse.json(
+        { error: "not_implemented" },
+        { status: resp.status }
+      );
+    }
     return NextResponse.json(
       { error: "Failed to fetch directory", details },
       { status: resp.status }
     );
   }
+  
 
   const data = await resp.json();
   return NextResponse.json(data);

--- a/src/app/api/data/employment/route.ts
+++ b/src/app/api/data/employment/route.ts
@@ -31,12 +31,18 @@ export async function POST(req: NextRequest) {
   );
 
   if (!resp.ok) {
-    const details = await resp.text();
+    const details = await resp.json().catch(() => ({}));
+    if (resp.status === 404 || resp.status === 501) {
+      return NextResponse.json(
+        { error: "not_implemented" },
+        { status: resp.status }
+      );
+    }
     return NextResponse.json(
       { error: "Failed to fetch employment", details },
       { status: resp.status }
     );
-  }
+  }  
 
   const data = await resp.json();
   return NextResponse.json(data);

--- a/src/app/api/data/individual/route.ts
+++ b/src/app/api/data/individual/route.ts
@@ -25,9 +25,18 @@ export async function POST(req: NextRequest) {
   );
 
   if (!resp.ok) {
-    const details = await resp.text();
-    return NextResponse.json({ error: "Failed to fetch individual", details }, { status: resp.status });
-  }
+    const details = await resp.json().catch(() => ({}));
+    if (resp.status === 404 || resp.status === 501) {
+      return NextResponse.json(
+        { error: "not_implemented" },
+        { status: resp.status }
+      );
+    }
+    return NextResponse.json(
+      { error: "Failed to fetch individual", details },
+      { status: resp.status }
+    );
+  }  
 
   const data = await resp.json();
   return NextResponse.json(data);

--- a/src/components/CompanyCard.tsx
+++ b/src/components/CompanyCard.tsx
@@ -19,6 +19,17 @@ export default function CompanyCard() {
 
   if (!company) return <Box>Loading company info...</Box>;
 
+  if (company?.error === "not_implemented") {
+    return (
+      <Box borderWidth="1px" borderRadius="md" p={4} bg="yellow.50">
+        <Text fontWeight="bold" color="yellow.800">
+          This provider does not implement the Company endpoint.
+        </Text>
+      </Box>
+    );
+  }
+  
+
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>
       <Text fontWeight="bold">{company.legal_name}</Text>

--- a/src/components/CompanyCard.tsx
+++ b/src/components/CompanyCard.tsx
@@ -17,6 +17,11 @@ export default function CompanyCard() {
     loadCompany();
   }, []);
 
+  // DATA HELPER FUNCTION
+  const show = (v: any) => (v === null || v === undefined || v === "" ? "—" : String(v));
+  const join = (arr?: any[], map?: (x: any) => string) =>
+    !arr || arr.length === 0 ? "—" : arr.map((x) => (map ? map(x) : String(x))).join(", ");
+
   if (!company) return <Box>Loading company info...</Box>;
 
   if (company?.error === "not_implemented") {
@@ -28,13 +33,42 @@ export default function CompanyCard() {
       </Box>
     );
   }
-  
+
 
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>
-      <Text fontWeight="bold">{company.legal_name}</Text>
-      <Text>{company.entity?.type}</Text>
-      <Text>{company.primary_address?.city}, {company.primary_address?.state}</Text>
+      <Text fontWeight="bold" mb={2}>Company</Text>
+      <Text>ID: {show(company?.id)}</Text>
+      <Text>Legal name: {show(company?.legal_name)}</Text>
+      <Text>Entity type: {show(company?.entity?.type)}</Text>
+      <Text>Entity subtype: {show(company?.entity?.subtype)}</Text>
+      <Text>EIN: {show(company?.ein)}</Text>
+      <Text>Primary email: {show(company?.primary_email)}</Text>
+      <Text>Primary phone: {show(company?.primary_phone_number)}</Text>
+  
+      <Text mt={2} fontWeight="semibold">Departments</Text>
+      <Text>
+        {join(company?.departments, (d) =>
+          `${d?.name ?? "—"}${d?.parent?.name ? ` (parent: ${d.parent.name})` : ""}`
+        )}
+      </Text>
+  
+      <Text mt={2} fontWeight="semibold">Locations</Text>
+      <Text>
+        {join(company?.locations, (l) =>
+          [l?.line1, l?.line2, l?.city, l?.state, l?.postal_code, l?.country]
+            .filter(Boolean)
+            .join(", ")
+        )}
+      </Text>
+  
+      <Text mt={2} fontWeight="semibold">Accounts</Text>
+      <Text>
+        {join(company?.accounts, (a) =>
+          `${a?.institution_name ?? "—"} • ${a?.account_name ?? "—"} • ${a?.account_type ?? "—"} • ****${(a?.account_number ?? "").slice(-4)}`
+        )}
+      </Text>
     </Box>
   );
+  
 }

--- a/src/components/DirectoryList.tsx
+++ b/src/components/DirectoryList.tsx
@@ -12,20 +12,40 @@ type Props = {
 export default function DirectoryList({ onSelect, selectedId }: Props) {
   // STATES
   const [employees, setEmployees] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   // HOOKS
   useEffect(() => {
     const loadDirectory = async () => {
-      const res = await fetch("/api/data/directory");
-      if (res.ok) {
+      try {
+        const res = await fetch("/api/data/directory");
         const data = await res.json();
-        setEmployees(data.individuals || []);
+        if (data.error === "not_implemented") {
+          setError("not_implemented");
+          setEmployees([]);
+        } else {
+          setEmployees(data.individuals || []);
+        }
+      } catch {
+        setError("Failed to load directory");
       }
     };
     loadDirectory();
   }, []);
+  
 
   if (!employees.length) return <Box>Loading directory...</Box>;
+
+  if (error === "not_implemented") {
+    return (
+      <Box borderWidth="1px" borderRadius="md" p={4} bg="yellow.50">
+        <Text fontWeight="bold" color="yellow.800">
+          This provider does not implement the Directory endpoint.
+        </Text>
+      </Box>
+    );
+  }
+  
 
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>

--- a/src/components/EmployeeDetails/EmploymentInfo.tsx
+++ b/src/components/EmployeeDetails/EmploymentInfo.tsx
@@ -26,6 +26,16 @@ export default function EmploymentInfo({ employeeId }: { employeeId: string }) {
 
   if (!data) return <Box>Loading employment...</Box>;
 
+  if (data?.error === "not_implemented") {
+    return (
+      <Box borderWidth="1px" borderRadius="md" p={4} bg="yellow.50">
+        <Text fontWeight="bold" color="yellow.800">
+          This provider does not implement the Employment endpoint.
+        </Text>
+      </Box>
+    );
+  }
+  
   return (
   <Box borderWidth="1px" borderRadius="md" p={4}>
     <Text fontWeight="bold" mb={2}>Employment Details</Text>

--- a/src/components/EmployeeDetails/IndividualInfo.tsx
+++ b/src/components/EmployeeDetails/IndividualInfo.tsx
@@ -28,6 +28,16 @@ export default function IndividualInfo({ employeeId }: { employeeId: string }) {
 
   if (!data) return <Box>Loading individual...</Box>;
 
+  if (data?.error === "not_implemented") {
+    return (
+      <Box borderWidth="1px" borderRadius="md" p={4} bg="yellow.50">
+        <Text fontWeight="bold" color="yellow.800">
+          This provider does not implement the Individual endpoint.
+        </Text>
+      </Box>
+    );
+  }  
+
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>
       <Text fontWeight="bold" mb={2}>Individual Details</Text>

--- a/src/components/EmployeeDetails/IndividualInfo.tsx
+++ b/src/components/EmployeeDetails/IndividualInfo.tsx
@@ -23,8 +23,6 @@ export default function IndividualInfo({ employeeId }: { employeeId: string }) {
 
   // DATA HELPER FUNCTIONS
   const show = (v: any) => (v === null || v === undefined || v === "" ? "—" : String(v));
-  const join = (arr?: any[], pick?: (x: any) => any) =>
-    !arr || arr.length === 0 ? "—" : arr.map((x) => show(pick ? pick(x) : x)).join(", ");
 
   if (!data) return <Box>Loading individual...</Box>;
 


### PR DESCRIPTION
## Description
Adds clear “provider does not implement this endpoint” handling and cleans up the UI layout.  
- Shows a banner when Finch returns 404/501 for **company**, **directory**, **individual**, or **employment**.  
- Simplified split-view UI: directory on the left, selected employee details on the right.  
- Displays all required fields with `—` for nulls.

## Acceptance Criteria
- [x] Not-implemented endpoints surface a visible banner
- [x] Directory → select employee → details render on the right
- [x] All fields shown; nulls rendered as `—`

## Type of PR
|     | Type               |
| --- | ------------------ |
| ✓   | :sparkles: New feature |

## Notes
Manual conditional used to validate the banner path; can switch to provider sandbox testing later.

## Preview
<img width="1381" height="735" alt="Screenshot 2025-09-05 at 5 31 01 PM" src="https://github.com/user-attachments/assets/16654d94-a725-4df2-99ee-3db2f95c9532" />


## What gif best describes this PR?
![ ](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXM3dHBqems3Nm9qNnZkMWh3bmQ0c2l0aTdsbHRwcXpnZ2llZjRsMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o7WTDH9gYo71TurPq/giphy.gif)
